### PR TITLE
fiexed issues #1, no go-import meta tags issue

### DIFF
--- a/base/tool/log.go
+++ b/base/tool/log.go
@@ -3,7 +3,7 @@ package tool
 import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"gopkg.in/natefinch/lumberjack"
+	"gopkg.in/natefinch/lumberjack.v2"
 	"os"
 	"path/filepath"
 	"sync"


### PR DESCRIPTION
fiexed issues #1, module lumberjack with no go-import meta tags

fixed issue as below:
https://github.com/hwholiday/short_url/issues/1